### PR TITLE
Fixed PASSWORD modal should always display after 'Open' clicked on Map URL Unique Key modal when map was Saved Private.

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,11 @@
 class HomeController < AuthenticatedController
+  before_action :reset_session, only: :index
   layout "file_manager"
   def index
+  end
+  private
+
+  def reset_session
+    session[:mindmap_id] = " "
   end
 end


### PR DESCRIPTION
#376 