### PR TITLE
Fixed unable to rake db:migrate AddCanvasToMindmap.

### DIFF
--- a/db/migrate/20220405072629_change_data_type_of_mindmap_canvas.rb
+++ b/db/migrate/20220405072629_change_data_type_of_mindmap_canvas.rb
@@ -1,0 +1,5 @@
+class ChangeDataTypeOfMindmapCanvas < ActiveRecord::Migration[5.2]
+  def change
+    change_column :mindmaps, :canvas, :longtext
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_21_105020) do
+ActiveRecord::Schema.define(version: 2022_04_05_072629) do
 
   create_table "active_admin_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "namespace"
@@ -78,7 +78,7 @@ ActiveRecord::Schema.define(version: 2022_03_21_105020) do
     t.binary "image"
     t.string "title", default: "Title"
     t.date "will_delete_at"
-    t.json "canvas"
+    t.text "canvas", limit: 4294967295
     t.index ["unique_key"], name: "index_mindmaps_on_unique_key", unique: true
   end
 


### PR DESCRIPTION
limitation:: we cannot preserve previous data with json to longtext format
#406 