### PR TITLE
Fixed: Clicking 'Save Private' after Logo was clicked should save the  map with the existing password, then return to the Index screen.

### DIFF
--- a/app/javascript/common/modals/confirm_save_key_modal.vue
+++ b/app/javascript/common/modals/confirm_save_key_modal.vue
@@ -127,7 +127,8 @@
       openPrivacy () {
         this.$emit("changeIsMsuitSaved")
         if(this.isSaveMap == null || this.isSaveMap == 'is_public') this.$emit("openPrivacy", this.isSaveMSuite)
-        else this.closeModal()
+        else if(this.isSaveMSuite) this.closeModal()
+        else window.open("/", "_self")
       },
       closeModal() {
         this.$refs.confirmSaveKeyModal.close()


### PR DESCRIPTION
#866 