### PR TITLE
Resolved: Spreadsheet: Totals is confusing on the pivot tables (graphs), so fix or remove.

### DIFF
--- a/app/javascript/components/spreadsheet/spreadsheet.vue
+++ b/app/javascript/components/spreadsheet/spreadsheet.vue
@@ -472,7 +472,8 @@
     font-weight: 500 !important;
     cursor: pointer;
   }
-  
+  thead > tr > th.pvtTotalLabel, .rowTotal, .pvtGrandTotal { display: none; }
+  tbody > tr > th.pvtTotalLabel, .colTotal, .pvtGrandTotal { display: none; }
 
   
 </style>


### PR DESCRIPTION
#876 