### PR TITLE
Worked on Notepad: Ordered List numbers and Unordered List bullets should be the same size as corresponding text.

### DIFF
--- a/app/javascript/components/notepad/notepad.vue
+++ b/app/javascript/components/notepad/notepad.vue
@@ -236,5 +236,11 @@
     }
   }
 </script>
-<style scoped>
+<style>
+  .ql-editor .ql-size-huge::before {
+    font-size: 2.5em;
+  }
+  .ql-editor .ql-size-large::before {
+    font-size: 1.5em;
+  }
 </style>


### PR DESCRIPTION
#731 