### PR TITLE
Fixed: Notepad During real time collaboration, when user scrolls downthe screen, the map should not automatically return to the top of the screen.

### DIFF
--- a/app/javascript/components/notepad/notepad.vue
+++ b/app/javascript/components/notepad/notepad.vue
@@ -75,9 +75,12 @@
               ])
             }
             else {
+              let element = $('.ql-editor')[0]
+              let notepadHeight = element.scrollTop
               if(this.temporaryUser !=localStorage.user){
                   this.qeditor.blur()
-                  this.qeditor.setContents(this.content)
+                  this.qeditor.setContents(new Delta(this.content))
+                  element.scrollTop = notepadHeight
               }
             }
           }


### PR DESCRIPTION
#925 