### PR TITLE
Worked on ToDo: Switch to Calendar dates should display the same as ToDo dates, instead of one day earlier.

### DIFF
--- a/app/javascript/components/calendar/calendar.vue
+++ b/app/javascript/components/calendar/calendar.vue
@@ -457,9 +457,12 @@
         this.mapColors = []
         this.uniqueColors = []
         this.calendar.store.getState().calendar.events.internalMap.clear()
+        let _this = this
         this.fetchedEvents.forEach((currentValue, index, rEvents)=> {
-          currentValue.duedate = moment(new Date(currentValue.duedate))
-          currentValue.startdate = moment(new Date(currentValue.startdate))
+          currentValue.duedate = _this.getTimeZone(currentValue.duedate)
+          currentValue.startdate = _this.getTimeZone(currentValue.startdate)
+          // currentValue.duedate = moment(new Date(currentValue.duedate))
+          // currentValue.startdate = moment(new Date(currentValue.startdate))
           let colorType = this.lightOrDark(currentValue.line_color)
           let textColor = '#F8F8F8'
           if (colorType != 'dark') textColor = '#020101'

--- a/app/javascript/mixins/common.js
+++ b/app/javascript/mixins/common.js
@@ -108,6 +108,7 @@ export default {
         return difference
       },
       getTimeZone(date){
+        date = new Date(date)
         return new Date(date.getTime() - date.getTimezoneOffset() * 60 * 1000)
       },
   }


### PR DESCRIPTION
#1150 